### PR TITLE
Correção para multiplos filmes por produtor

### DIFF
--- a/src/core/csv-file/csv.type.ts
+++ b/src/core/csv-file/csv.type.ts
@@ -1,5 +1,3 @@
-// year;title;studios;producers;winner
-
 export type CsvType = {
   year: number;
   title: string;

--- a/src/movie/movie.service.ts
+++ b/src/movie/movie.service.ts
@@ -8,25 +8,9 @@ export class MovieService {
   constructor(
     @Inject(MovieEnum.MOVIE_REPOSITORY)
     private readonly movieRepository: Repository<Movies>,
-  ) {}
-
-  async findAll(): Promise<Movies[]> {
-    return this.movieRepository.find({
-      relations: ['producers', 'studios'],
-    });
-  }
+  ) { }
 
   async saveMovies(movies: Movies[]): Promise<Movies[]> {
     return this.movieRepository.save(movies);
-  }
-
-  async getRangeAwards(): Promise<Movies[]> {
-    const databaseWinnerMovies = this.movieRepository.find({
-      where: {
-        winner: true,
-      },
-    });
-
-    return databaseWinnerMovies;
   }
 }

--- a/src/producer/producer.interface.ts
+++ b/src/producer/producer.interface.ts
@@ -1,11 +1,20 @@
-interface ProducerAwards {
+import { Producers } from "./producer.entity";
+
+export interface IProducerAwards {
   producer: string;
   interval: number;
   previousWin: number;
   followingWin: number;
 }
 
-interface ResultsProducerAwards {
-  min: ProducerAwards[];
-  max: ProducerAwards[];
+export interface IResultsProducerAwards {
+  min: IProducerAwards[];
+  max: IProducerAwards[];
+}
+
+export interface IProducerRepository {
+  findByName(name: string): Promise<Producers | null>;
+  save(producer: Producers): Promise<Producers>;
+  findWinningProducers(): Promise<Producers[]>;
+  count(): Promise<number>;
 }

--- a/src/producer/producer.providers.ts
+++ b/src/producer/producer.providers.ts
@@ -1,11 +1,12 @@
 import { DataSource } from 'typeorm';
 import { ProducerEnum } from './producer.enum';
 import { Producers } from './producer.entity';
+import { ProducerRepository } from './producer.repository';
 
 export const producerProviders = [
   {
     provide: ProducerEnum.PRODUCER_REPOSITORY,
-    useFactory: (dataSource: DataSource) => dataSource.getRepository(Producers),
+    useFactory: (dataSource: DataSource) => new ProducerRepository(dataSource.getRepository(Producers)),
     inject: [ProducerEnum.DATA_SOURCE],
   },
 ];

--- a/src/producer/producer.repository.ts
+++ b/src/producer/producer.repository.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { Producers } from './producer.entity';
+import { IProducerRepository } from './producer.interface';
+
+@Injectable()
+export class ProducerRepository implements IProducerRepository {
+    constructor(private readonly repository: Repository<Producers>) { }
+
+    async findByName(name: string): Promise<Producers | null> {
+        return this.repository.findOne({ where: { name } });
+    }
+
+    async save(producer: Producers): Promise<Producers> {
+        return this.repository.save(producer);
+    }
+
+    async findWinningProducers(): Promise<Producers[]> {
+        return this.repository
+            .createQueryBuilder('producer')
+            .leftJoinAndSelect('producer.movies', 'movie')
+            .where('movie.winner = :winner', { winner: true })
+            .getMany();
+    }
+
+    async count(): Promise<number> {
+        return this.repository.count();
+    }
+}

--- a/src/producer/producer.service.ts
+++ b/src/producer/producer.service.ts
@@ -1,114 +1,53 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { ProducerEnum } from './producer.enum';
-import { Repository } from 'typeorm';
 import { Producers } from './producer.entity';
+import { IProducerAwards, IProducerRepository, IResultsProducerAwards } from './producer.interface';
 
 @Injectable()
 export class ProducerService {
   constructor(
     @Inject(ProducerEnum.PRODUCER_REPOSITORY)
-    private readonly producerRepository: Repository<Producers>,
-  ) {}
-
-  public async saveProducer(producer: Producers): Promise<Producers> {
-    return this.producerRepository.save(producer);
-  }
+    private readonly producerRepository: IProducerRepository
+  ) { }
 
   public async upsertProducer(producer: Producers): Promise<Producers> {
-    const databaseProducer = await this.producerRepository.findOne({
-      where: {
-        name: producer.name,
+    return (await this.producerRepository.findByName(producer.name)) ?? this.producerRepository.save(producer);
+  }
+
+  public async getProducerWithAwardRange(): Promise<IResultsProducerAwards> {
+    const databaseWinnerProducers = await this.producerRepository.findWinningProducers();
+
+    const producerAwards = this.calculateAwardIntervals(databaseWinnerProducers);
+    const awardIntervals = [...new Set(producerAwards.map(({ interval }) => interval))];
+    const [minInterval, maxInterval] = [Math.min(...awardIntervals), Math.max(...awardIntervals)];
+
+    return this.filterAwardsByInterval(minInterval, maxInterval, producerAwards);
+  }
+
+  private filterAwardsByInterval(minInterval: number, maxInterval: number, producerAwards: IProducerAwards[]): IResultsProducerAwards {
+
+    return producerAwards.reduce(
+      (acc, award) => {
+        if (award.interval === minInterval) acc.min.push(award);
+        if (award.interval === maxInterval) acc.max.push(award);
+        return acc;
       },
+      { min: [], max: [] } as IResultsProducerAwards
+    );
+  }
+
+  private calculateAwardIntervals(winnerProducers: Producers[]): IProducerAwards[] {
+
+    return winnerProducers.flatMap(({ name, movies }) => {
+      if (movies.length < 2) return [];
+
+      const sortedMovies = [...movies].sort((a, b) => a.year - b.year);
+      return sortedMovies.slice(1).map((movie, i) => ({
+        producer: name,
+        interval: movie.year - sortedMovies[i].year,
+        previousWin: sortedMovies[i].year,
+        followingWin: movie.year,
+      }));
     });
-
-    return databaseProducer ?? this.producerRepository.save(producer);
-  }
-
-  async findAll(): Promise<Producers[]> {
-    return this.producerRepository
-      .createQueryBuilder('producer')
-      .leftJoinAndSelect('producer.movies', 'movie')
-      .where('movie.winner = :winner', { winner: true })
-      .getMany();
-  }
-
-  public async getProducerWithAwardRange(): Promise<ResultsProducerAwards> {
-    const databaseWinnerProducers = await this.producerRepository
-      .createQueryBuilder('producer')
-      .leftJoinAndSelect('producer.movies', 'movie')
-      .where('movie.winner = :winner', { winner: true })
-      .getMany();
-
-    const resultsProducerAwards: ResultsProducerAwards = {
-      min: [],
-      max: [],
-    };
-
-    resultsProducerAwards.min = this.getMinRange(databaseWinnerProducers);
-    resultsProducerAwards.max = this.getMaxRange(databaseWinnerProducers);
-
-    return resultsProducerAwards;
-  }
-
-  private getMinRange(winnerProducers: Producers[]): ProducerAwards[] {
-    const producerAwards = this.calculateProducerAwards(
-      winnerProducers,
-      (a, b) => a < b,
-      Number.MAX_SAFE_INTEGER,
-    );
-    const minInterval = Math.min(
-      ...producerAwards.map((producer) => producer.interval),
-    );
-    return producerAwards.filter(
-      (producer) => producer.interval === minInterval,
-    );
-  }
-
-  private getMaxRange(winnerProducers: Producers[]): ProducerAwards[] {
-    const producerAwards = this.calculateProducerAwards(
-      winnerProducers,
-      (a, b) => a > b,
-      0,
-    );
-    const maxInterval = Math.max(
-      ...producerAwards.map((producer) => producer.interval),
-    );
-
-    return producerAwards.filter(
-      (producer) => producer.interval === maxInterval,
-    );
-  }
-
-  private calculateProducerAwards(
-    winnerProducers: Producers[],
-    comparator: (a: number, b: number) => boolean,
-    initialValue: number,
-  ): ProducerAwards[] {
-    const results = winnerProducers
-      .filter((producer) => producer.movies.length > 1)
-      .map((producer) => {
-        const producerMovies = producer.movies.sort((a, b) => a.year - b.year);
-        let bestInterval = initialValue;
-        let previousWin = 0;
-        let followingWin = 0;
-
-        for (let i = 1; i < producerMovies.length; i++) {
-          const interval = producerMovies[i].year - producerMovies[i - 1].year;
-          if (comparator(interval, bestInterval)) {
-            bestInterval = interval;
-            previousWin = producerMovies[i - 1].year;
-            followingWin = producerMovies[i].year;
-          }
-        }
-
-        return {
-          producer: producer.name,
-          interval: bestInterval,
-          previousWin,
-          followingWin,
-        };
-      });
-
-    return results;
   }
 }

--- a/src/producer/producers.controller.ts
+++ b/src/producer/producers.controller.ts
@@ -1,5 +1,6 @@
 import { Controller, Get, Inject } from '@nestjs/common';
 import { ProducerService } from './producer.service';
+import { IResultsProducerAwards } from './producer.interface';
 
 @Controller('api/producer')
 export class ProducerController {
@@ -8,7 +9,7 @@ export class ProducerController {
   ) { }
 
   @Get('range-awards')
-  public async getRangeAwards(): Promise<ResultsProducerAwards> {
+  public async getRangeAwards(): Promise<IResultsProducerAwards> {
     return this.producerService.getProducerWithAwardRange();
   }
 }

--- a/src/studio/studio.service.ts
+++ b/src/studio/studio.service.ts
@@ -8,11 +8,7 @@ export class StudioService {
   constructor(
     @Inject(StudioEnum.STUDIO_REPOSITORY)
     private readonly studioRepository: Repository<Studios>,
-  ) {}
-
-  public async saveStudio(studio: Studios): Promise<Studios> {
-    return this.studioRepository.save(studio);
-  }
+  ) { }
 
   public async upsertStudio(studio: Studios): Promise<Studios> {
     const databaseStudio = await this.studioRepository.findOne({

--- a/test/config/database.providers.ts
+++ b/test/config/database.providers.ts
@@ -1,20 +1,21 @@
 import { DataSource } from 'typeorm';
-import { join } from 'path';
-import { ProducerEnum } from '../../src/producer/producer.enum';
+import { Movies } from '../../src/movie/movie.entity';
+import { Producers } from '../../src/producer/producer.entity';
+import { Studios } from '../../src/studio/studio.entity';
 
 export const testDatabaseProviders = [
     {
-        provide: ProducerEnum.DATA_SOURCE,
+        provide: 'DATA_SOURCE',
         useFactory: async () => {
             const dataSource = new DataSource({
                 type: 'sqlite',
                 database: ':memory:',
-                entities: [join(__dirname, '../../**/*.entity{.ts,.js}')],
+                entities: [Movies, Producers, Studios],
                 synchronize: true,
                 dropSchema: true
             });
 
             return dataSource.initialize();
         },
-    },
+    }
 ];

--- a/test/csv-file.e2e-spec.ts
+++ b/test/csv-file.e2e-spec.ts
@@ -6,18 +6,21 @@ import { ProducerModule } from '../src/producer/producer.module';
 import { StudioModule } from '../src/studio/studio.module';
 import { TestDatabaseModule } from './config/e2e-database.module';
 import { Movies } from '../src/movie/movie.entity';
-import { Repository } from 'typeorm';
-import { Producers } from '../src/producer/producer.entity';
+import { DataSource, Repository } from 'typeorm';
 import { Studios } from '../src/studio/studio.entity';
 import { ProducerEnum } from '../src/producer/producer.enum';
 import { MovieEnum } from '../src/movie/movie.enum';
 import { StudioEnum } from '../src/studio/studio.enum';
+import { IProducerRepository } from '../src/producer/producer.interface';
+
+jest.setTimeout(10000);
 
 describe('ImportCSVProvider (e2e)', () => {
     let app: INestApplication;
     let moviesRepository: Repository<Movies>;
-    let producerRepository: Repository<Producers>;
+    let producerRepository: IProducerRepository;
     let studioRepository: Repository<Studios>;
+    let dataSource: DataSource;
 
     beforeAll(async () => {
         const moduleFixture: TestingModule = await Test.createTestingModule({
@@ -35,11 +38,21 @@ describe('ImportCSVProvider (e2e)', () => {
         await app.init();
 
         moviesRepository = moduleFixture.get<Repository<Movies>>(MovieEnum.MOVIE_REPOSITORY);
-        producerRepository = moduleFixture.get<Repository<Producers>>(ProducerEnum.PRODUCER_REPOSITORY);
+        producerRepository = moduleFixture.get<IProducerRepository>(ProducerEnum.PRODUCER_REPOSITORY);;
         studioRepository = moduleFixture.get<Repository<Studios>>(StudioEnum.STUDIO_REPOSITORY);
+        dataSource = moduleFixture.get<DataSource>('DATA_SOURCE');
+
     });
 
-    it('should import CSV data and save movies', async () => {
+    afterAll(async () => {
+        if (dataSource && dataSource.isInitialized) {
+            await dataSource.destroy();
+        }
+
+        await app.close();
+    });
+
+    it('should read CSV, structure the data and insert it into the database.', async () => {
         const countMovies = await moviesRepository.count();
         const countProducers = await producerRepository.count();
         const countStudios = await studioRepository.count();
@@ -47,9 +60,5 @@ describe('ImportCSVProvider (e2e)', () => {
         expect(countMovies).toBe(206);
         expect(countProducers).toBe(367);
         expect(countStudios).toBe(59);
-    });
-
-    afterAll(async () => {
-        await app.close();
     });
 });

--- a/test/producer.e2e-spec.ts
+++ b/test/producer.e2e-spec.ts
@@ -3,33 +3,287 @@ import { Test, TestingModule } from "@nestjs/testing";
 import { AppModule } from "../src/app.module";
 import { TestDatabaseModule } from "./config/e2e-database.module";
 import * as request from 'supertest';
+import { CsvService } from "../src/core/csv-file/csv.service";
+import { DataSource } from "typeorm";
 
 describe('Producer (e2e)', () => {
     let app: INestApplication;
+    let csvService: CsvService;
+    let dataSource: DataSource;
 
-    beforeAll(async () => {
+    beforeEach(async () => {
+
+        jest.clearAllMocks();
+
         const moduleFixture: TestingModule = await Test.createTestingModule({
             imports: [
                 AppModule,
                 TestDatabaseModule
             ],
-        }).compile();
+        })
+            .overrideProvider(CsvService)
+            .useValue({
+                readCSV: jest.fn()
+            })
+            .compile();
 
         app = moduleFixture.createNestApplication();
 
-        await app.init();
+        csvService = moduleFixture.get<CsvService>(CsvService);
+        dataSource = moduleFixture.get<DataSource>('DATA_SOURCE');
     });
 
-    it('/api/producer/range-awards (GET)', async () => {
+    afterEach(async () => {
+        if (dataSource && dataSource.isInitialized) {
+            await dataSource.destroy();
+        }
 
-        const response = await request(app.getHttpServer())
-            .get('/api/producer/range-awards')
-            .expect(200)
-            .expect('Content-Type', /json/)
-            .expect({
+        await app.close();
+    });
+
+    afterAll(async () => {
+        if (dataSource && dataSource.isInitialized) {
+            await dataSource.destroy();
+        }
+
+        await app.close();
+    });
+
+    describe('/api/producer/range-awards (GET)', () => {
+
+        it('should return the producer with the smallest and the largest interval between wins', async () => {
+            (csvService as any).readCSV = jest.fn().mockResolvedValue([
+                { "year": 1990, "title": "Movie A", "studios": "Studio 1", "producers": "Producer X", "winner": true },
+                { "year": 1992, "title": "Movie B", "studios": "Studio 2", "producers": "Producer X", "winner": true },
+                { "year": 2000, "title": "Movie C", "studios": "Studio 3", "producers": "Producer Y", "winner": true },
+                { "year": 2010, "title": "Movie D", "studios": "Studio 4", "producers": "Producer Y", "winner": true },
+            ]);
+
+            await app.init();
+
+            const response = await request(app.getHttpServer()).get('/api/producer/range-awards');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual({
                 "min": [
                     {
-                        "producer": "Joel Silver",
+                        "producer": "Producer X",
+                        "interval": 2,
+                        "previousWin": 1990,
+                        "followingWin": 1992
+                    }
+                ],
+                "max": [
+                    {
+                        "producer": "Producer Y",
+                        "interval": 10,
+                        "previousWin": 2000,
+                        "followingWin": 2010
+                    }
+                ]
+            });
+        });
+
+        it('should return two producers with the smallest interval and one with the largest interval', async () => {
+            (csvService as any).readCSV = jest.fn().mockResolvedValue([
+                { "year": 1991, "title": "Movie A", "studios": "Studio 1", "producers": "Producer X", "winner": true },
+                { "year": 1992, "title": "Movie B", "studios": "Studio 2", "producers": "Producer X", "winner": true },
+                { "year": 2005, "title": "Movie F", "studios": "Studio 6", "producers": "Producer Z", "winner": true },
+                { "year": 2006, "title": "Movie G", "studios": "Studio 7", "producers": "Producer Z", "winner": true },
+                { "year": 2000, "title": "Movie C", "studios": "Studio 3", "producers": "Producer Y", "winner": true },
+                { "year": 2010, "title": "Movie D", "studios": "Studio 4", "producers": "Producer Y", "winner": true }
+            ]);
+
+            await app.init();
+
+            const response = await request(app.getHttpServer()).get('/api/producer/range-awards');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual({
+                "min": [
+                    {
+                        "producer": "Producer X",
+                        "interval": 1,
+                        "previousWin": 1991,
+                        "followingWin": 1992
+                    },
+                    {
+                        "producer": "Producer Z",
+                        "interval": 1,
+                        "previousWin": 2005,
+                        "followingWin": 2006
+                    }
+                ],
+                "max": [
+                    {
+                        "producer": "Producer Y",
+                        "interval": 10,
+                        "previousWin": 2000,
+                        "followingWin": 2010
+                    }
+                ]
+            });
+        });
+
+        it('should return one producer with the smallest interval and two with the largest interval', async () => {
+            (csvService as any).readCSV = jest.fn().mockResolvedValue([
+                { "year": 1990, "title": "Movie A", "studios": "Studio 1", "producers": "Producer X", "winner": true },
+                { "year": 1992, "title": "Movie B", "studios": "Studio 2", "producers": "Producer X", "winner": true },
+                { "year": 2000, "title": "Movie D", "studios": "Studio 4", "producers": "Producer Y", "winner": true },
+                { "year": 2020, "title": "Movie E", "studios": "Studio 5", "producers": "Producer Y", "winner": true },
+                { "year": 1995, "title": "Movie H", "studios": "Studio 8", "producers": "Producer W", "winner": true },
+                { "year": 2015, "title": "Movie I", "studios": "Studio 9", "producers": "Producer W", "winner": true }
+            ]);
+
+            await app.init();
+
+            const response = await request(app.getHttpServer()).get('/api/producer/range-awards');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual({
+                "min": [
+                    {
+                        "producer": "Producer X",
+                        "interval": 2,
+                        "previousWin": 1990,
+                        "followingWin": 1992
+                    }
+                ],
+                "max": [
+                    {
+                        "producer": "Producer Y",
+                        "interval": 20,
+                        "previousWin": 2000,
+                        "followingWin": 2020
+                    },
+                    {
+                        "producer": "Producer W",
+                        "interval": 20,
+                        "previousWin": 1995,
+                        "followingWin": 2015
+                    }
+                ]
+            });
+        });
+
+        it('should return two producers with the smallest interval and two with the largest interval', async () => {
+            (csvService as any).readCSV = jest.fn().mockResolvedValue([
+                { "year": 1991, "title": "Movie A", "studios": "Studio 1", "producers": "Producer X", "winner": true },
+                { "year": 1992, "title": "Movie B", "studios": "Studio 2", "producers": "Producer X", "winner": true },
+                { "year": 2005, "title": "Movie F", "studios": "Studio 6", "producers": "Producer Z", "winner": true },
+                { "year": 2006, "title": "Movie G", "studios": "Studio 7", "producers": "Producer Z", "winner": true },
+                { "year": 2000, "title": "Movie D", "studios": "Studio 4", "producers": "Producer Y", "winner": true },
+                { "year": 2020, "title": "Movie E", "studios": "Studio 5", "producers": "Producer Y", "winner": true },
+                { "year": 1995, "title": "Movie H", "studios": "Studio 8", "producers": "Producer W", "winner": true },
+                { "year": 2015, "title": "Movie I", "studios": "Studio 9", "producers": "Producer W", "winner": true }
+            ]);
+
+            await app.init();
+
+            const response = await request(app.getHttpServer()).get('/api/producer/range-awards');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual({
+                "min": [
+                    {
+                        "producer": "Producer X",
+                        "interval": 1,
+                        "previousWin": 1991,
+                        "followingWin": 1992
+                    },
+                    {
+                        "producer": "Producer Z",
+                        "interval": 1,
+                        "previousWin": 2005,
+                        "followingWin": 2006
+                    }
+                ],
+                "max": [
+                    {
+                        "producer": "Producer Y",
+                        "interval": 20,
+                        "previousWin": 2000,
+                        "followingWin": 2020
+                    },
+                    {
+                        "producer": "Producer W",
+                        "interval": 20,
+                        "previousWin": 1995,
+                        "followingWin": 2015
+                    }
+                ]
+            });
+        });
+
+        it('should return two smallest intervals and one largest interval considering multiple producers', async () => {
+            (csvService as any).readCSV = jest.fn().mockResolvedValue([
+                { "year": 1995, "title": "Movie A", "studios": "Studio 1", "producers": "Producer X and Producer Y", "winner": true },
+                { "year": 1997, "title": "Movie B", "studios": "Studio 2", "producers": "Producer X and Producer Y", "winner": true },
+                { "year": 2000, "title": "Movie C", "studios": "Studio 3 and Studio 4", "producers": "Producer Z", "winner": true },
+                { "year": 2015, "title": "Movie D", "studios": "Studio 5", "producers": "Producer Z", "winner": true }
+            ]);
+
+            await app.init();
+
+            const response = await request(app.getHttpServer()).get('/api/producer/range-awards');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual({
+                "min": [
+                    {
+                        "producer": "Producer Y",
+                        "interval": 2,
+                        "previousWin": 1995,
+                        "followingWin": 1997
+                    },
+                    {
+                        "producer": "Producer X",
+                        "interval": 2,
+                        "previousWin": 1995,
+                        "followingWin": 1997
+                    },
+                ],
+                "max": [
+                    {
+                        "producer": "Producer Z",
+                        "interval": 15,
+                        "previousWin": 2000,
+                        "followingWin": 2015
+                    }
+                ]
+            });
+        });
+
+        it('should return the smallest interval with multiple producers and the largest interval for a single producer', async () => {
+            (csvService as any).readCSV = jest.fn().mockResolvedValue([
+                { "year": 1988, "title": "Movie E", "studios": "Studio 1 and Studio 2", "producers": "Producer A", "winner": true },
+                { "year": 1989, "title": "Movie F", "studios": "Studio 3", "producers": "Producer A", "winner": true },
+                { "year": 1990, "title": "Movie G", "studios": "Studio 4", "producers": "Producer B and Producer C", "winner": true },
+                { "year": 1991, "title": "Movie H", "studios": "Studio 5", "producers": "Producer B, Producer C and Producer D", "winner": true },
+                { "year": 2020, "title": "Movie J", "studios": "Studio 8", "producers": "Producer D", "winner": true }
+            ]);
+
+            await app.init();
+
+            const response = await request(app.getHttpServer()).get('/api/producer/range-awards');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual({
+                "min": [
+                    {
+                        "producer": "Producer A",
+                        "interval": 1,
+                        "previousWin": 1988,
+                        "followingWin": 1989
+                    },
+                    {
+                        "producer": "Producer C",
+                        "interval": 1,
+                        "previousWin": 1990,
+                        "followingWin": 1991
+                    },
+                    {
+                        "producer": "Producer B",
                         "interval": 1,
                         "previousWin": 1990,
                         "followingWin": 1991
@@ -37,18 +291,54 @@ describe('Producer (e2e)', () => {
                 ],
                 "max": [
                     {
-                        "producer": "Matthew Vaughn",
-                        "interval": 13,
-                        "previousWin": 2002,
-                        "followingWin": 2015
+                        "producer": "Producer D",
+                        "interval": 29,
+                        "previousWin": 1991,
+                        "followingWin": 2020
                     }
                 ]
             });
+        });
 
-        return response;
-    });
+        it('should return one smallest interval and two largest intervals with multiple producers', async () => {
+            (csvService as any).readCSV = jest.fn().mockResolvedValue([
+                { "year": 1992, "title": "Movie K", "studios": "Studio 1 and Studio 3", "producers": "Producer X", "winner": true },
+                { "year": 1994, "title": "Movie L", "studios": "Studio 2 and Studio 4", "producers": "Producer X", "winner": true },
+                { "year": 2000, "title": "Movie M", "studios": "Studio 5", "producers": "Producer Y and Producer Z", "winner": true },
+                { "year": 2018, "title": "Movie N", "studios": "Studio 6", "producers": "Producer Y and Producer Z", "winner": true },
+                { "year": 2022, "title": "Movie O", "studios": "Studio 7 and Studio 8", "producers": "Producer W", "winner": true },
+                { "year": 2025, "title": "Movie P", "studios": "Studio 9", "producers": "Producer W", "winner": true }
+            ]);
 
-    afterAll(async () => {
-        await app.close();
+            await app.init();
+
+            const response = await request(app.getHttpServer()).get('/api/producer/range-awards');
+
+            expect(response.status).toBe(200);
+            expect(response.body).toEqual({
+                "min": [
+                    {
+                        "producer": "Producer X",
+                        "interval": 2,
+                        "previousWin": 1992,
+                        "followingWin": 1994
+                    }
+                ],
+                "max": [
+                    {
+                        "producer": "Producer Z",
+                        "interval": 18,
+                        "previousWin": 2000,
+                        "followingWin": 2018
+                    },
+                    {
+                        "producer": "Producer Y",
+                        "interval": 18,
+                        "previousWin": 2000,
+                        "followingWin": 2018
+                    }
+                ]
+            });
+        });
     });
 });


### PR DESCRIPTION
Problema:
ℹ️O código não estava tratando corretamente períodos diferentes com o mesmo intervalo para um produtor, o que causava inconsistências no retorno da API.

Solução:
✔️ A lógica foi ajustada para garantir que todos os intervalos dos filmes de cada produtor sejam considerados corretamente.
✔️ Além disso, foram adicionados mais casos de teste no E2E da API para reforçar a validação e garantir ainda mais a integridade dos dados.